### PR TITLE
Target netstandard2.0 Instead

### DIFF
--- a/src/ExpoCommunityNotificationServer.csproj
+++ b/src/ExpoCommunityNotificationServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>ExpoCommunityNotificationServer</RootNamespace>
     <Authors>Mikita Slaunikau, Ashley Messer</Authors>
     <Company></Company>


### PR DESCRIPTION
1. Resolves build warning of `NETSDK1138: The target framework 'netcoreapp2.2' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy`
2. Supports a wider range of platforms.